### PR TITLE
Update node to 12.22.0

### DIFF
--- a/eslint/Dockerfile
+++ b/eslint/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.9.0
+FROM node:12.22.0
 
 LABEL "com.github.actions.name"="Run ESLint"
 LABEL "com.github.actions.description"="Run ESLint, the pluggable linting utility for JavaScript and JSX."


### PR DESCRIPTION
Apparently because of the recent SSL vulnerability, ESlint is now requiring 12.22.0 as the minimum Node version. This branch hopes to be a quick fix. Not sure how to test this, so I just bumped the version number to the required minimum. See below for an example of the issue:

https://github.com/associatedpackaging/www.supplybox.com/runs/3859877281