### PR TITLE
Update node to 12.22.0 for stylelint

### DIFF
--- a/stylelint/Dockerfile
+++ b/stylelint/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.9.0
+FROM node:12.22.0
 
 LABEL "com.github.actions.name"="Run stylelint"
 LABEL "com.github.actions.description"="Run stylelint, a mighty, modern linter that helps you avoid errors and enforce conventions in your styles."


### PR DESCRIPTION
When we updated node elsewhere, I missed this one and it seems to cause an error now when running SupplyBox stylelint tests.

See for example: https://github.com/associatedpackaging/www.supplybox.com/runs/3966068950?check_suite_focus=true